### PR TITLE
main-screen title

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,8 @@
   },
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "typescript.tsdk": "node_modules\\typescript\\lib"
+  "typescript.tsdk": "node_modules\\typescript\\lib",
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "vscode.typescript-language-features"
+  }
 }

--- a/src/components/MainContent/index.tsx
+++ b/src/components/MainContent/index.tsx
@@ -4,8 +4,8 @@ export const MainContent = () => (
   <Flex
     bg="#f1f1f1"
     w="full"
-    marginLeft="80.5px"
-    marginTop="37.5px"
+    marginLeft="80px"
+    marginTop="37px"
     alignItems="start"
   >
     <Text width="450px" fontSize="26px">

--- a/src/components/MainContent/index.tsx
+++ b/src/components/MainContent/index.tsx
@@ -1,0 +1,16 @@
+import { Flex, Text } from '@chakra-ui/react';
+
+export const MainContent = () => (
+  <Flex
+    bg="#f1f1f1"
+    w="full"
+    marginLeft="80.5px"
+    marginTop="37.5px"
+    alignItems="start"
+  >
+    <Text width="450px" fontSize="26px">
+      <span style={{ color: '#F9A109' }}>Shoppingify</span> Allows you take your
+      shopping list wherever you go
+    </Text>
+  </Flex>
+);

--- a/src/components/MainScreen/index.tsx
+++ b/src/components/MainScreen/index.tsx
@@ -1,10 +1,12 @@
 import { Flex } from '@chakra-ui/react';
+import { MainContent } from '../MainContent';
 import { SideBar } from '@/components/SideBar';
 import { SideDrawer } from '@/components/SideDrawer';
 
 export const MainScreen = () => (
   <Flex bg="#f1f1f1" w="full" justifyContent="space-between">
     <SideBar />
+    <MainContent />
     <SideDrawer />
   </Flex>
 );

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,9 +1,15 @@
 import type { AppProps } from 'next/app';
-import { ChakraProvider } from '@chakra-ui/react';
+import { ChakraProvider, extendTheme } from '@chakra-ui/react';
+
+const theme = extendTheme({
+  fonts: {
+    body: `'Quicksand', sans-serif`,
+  },
+});
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <ChakraProvider>
+    <ChakraProvider theme={theme}>
       <Component {...pageProps} />
 
       {/* We need to do this to make sure that the page have at least 100% height */}


### PR DESCRIPTION
This PR is regarding issue #14

I've create the "MainContent" component to place the Title following the Figma Design in the middle of the page, how i did that?
 
- First
I set the font of the hole project as the same font on Figma, adding an "ExtendTheme" with the correct font on _App.tsx page.

- Second
after created the component to be in the middle, i use the "Text" component from chackra ui inside a "Flex" component.

- Third
i positioned the Text component on the right place following the Figma Design.

- Fourth
i use a "span" to highlight the name of the project with yellow.
Why a "span" instead of "Text" component? because this component act as a "div" and this is the result:

![Capturar](https://user-images.githubusercontent.com/103784814/229327848-db495fda-4295-4fff-b52a-81c8ae18e888.PNG)
--- 
![result-wrong](https://user-images.githubusercontent.com/103784814/229327862-1adef9da-147e-41cf-808f-da53d37083ac.PNG)

using a "span" make the title the same as the Figma.

![correct-code](https://user-images.githubusercontent.com/103784814/229327876-9adb2132-f64b-4f0f-86f1-15a80e300813.PNG)
---
![result](https://user-images.githubusercontent.com/103784814/229327886-25310c78-a59e-45cf-9bd2-29bde32a51ca.PNG)

